### PR TITLE
POPI Policy, research consent for registration and menu option

### DIFF
--- a/go-app-ussd_registration.js
+++ b/go-app-ussd_registration.js
@@ -1794,7 +1794,7 @@ go.app = (function () {
     });
 
     self.add('state_menconnect_popi_consent_accept', function (name) {
-      return new MenuState(name, {
+      return new EndState(name, {
         next: "state_start",
         text: $(
           "Thank you for accepting the policy."

--- a/go-app-ussd_registration.js
+++ b/go-app-ussd_registration.js
@@ -1594,10 +1594,12 @@ go.app = (function () {
         question: get_content(name).context(),
         accept_labels: true,
         choices: [
-          new Choice("state_menconnect_info", $("What info does MenConnect collect?")),
-          new Choice("state_menconnect_info_need", $("Why does MenConnect need my info?")),
+          new Choice("state_menconnect_info", $("What info is collected?")),
+          new Choice("state_menconnect_info_need", $("Why do you need my info?")),
           new Choice("state_menconnect_info_visibility", $("Who can see my info?")),
-          new Choice("state_menconnect_info_duration", $("How long is my info kept?"))
+          new Choice("state_menconnect_info_duration", $("How long is my info kept?")),
+          new Choice("state_menconnect_popi", $("View Privacy Policy")),
+          new Choice("state_registered", $("Back"))
         ]
       });
     });
@@ -1639,6 +1641,164 @@ go.app = (function () {
         choices: [
           new Choice("state_processing_info_menu", $("Back"))
         ]
+      });
+    });
+
+    self.add('state_menconnect_popi', function (name) {
+      return new MenuState(name, {
+        question: $(
+          "MenConnect Keeps your personal info private & confidential. It's used with " +
+          "your consent to send you health messages. You can opt out at any time"),
+        error: get_content("state_generic_error").context(),
+        choices: [
+          new Choice("state_menconnect_start_popi_flow", $("Next"))
+        ]
+      });
+    });
+
+    self.add('state_menconnect_start_popi_flow', function (name, opts) {
+      var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
+      
+      return self.rapidpro
+        .start_flow(
+          self.im.config.popi_flow_uuid,
+          null,
+          "whatsapp:" + _.trim(msisdn, "+"))
+        .then(function() {
+          return self.states.create("state_menconnect_popi_consent");
+        }).catch(function(e) {
+          // Go to error state after 3 failed HTTP requests
+          opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+          if(opts.http_error_count === 3) {
+            self.im.log.error(e.message);
+            return self.states.create("__error__");
+          }
+          return self.states.create("state_start", opts);
+        });
+    });
+
+    self.add('state_menconnect_popi_consent', function (name) {
+      var contact = self.im.user.get_answer("contact");
+      var popi_consent = (_.toUpper(_.get(contact, "fields.popi_consent")));
+      if (popi_consent === self.im.config.popi_consent) {
+        return self.states.create("state_menconnect_popi_consent_view");
+      }
+      return new MenuState(name, {
+        question: $(
+          "Do you agree to the MenConnect privacy policy that was just sent to you on {{current_channel}}").context({
+          current_channel: self.contact_current_channel(contact)
+      }),
+        error: get_content("state_generic_error").context(),
+        accept_labels: true,
+        choices: [
+          new Choice("state_trigger_rapidpro_popi_flow", $("Yes")),
+          new Choice("state_menconnect_popi_no_consent_confirm", $("No"))
+        ]
+      });
+    });
+
+    self.add('state_menconnect_popi_consent_view', function (name) {
+      var contact = self.im.user.answers.contact;
+      return new MenuState(name, {
+        question: $(
+          "The MenConnect privacy policy was just sent to you on {{current_channel}}").context({
+          current_channel: self.contact_current_channel(contact)
+      }),
+        error: get_content("state_generic_error").context(),
+        choices: [
+          new Choice("state_start", $("Menu")),
+          new Choice("state_exit", $("Exit"))
+        ]
+      });
+    });
+
+    self.add('state_menconnect_popi_no_consent_confirm', function (name) {
+      return new MenuState(name, {
+        question: $("Unfortunately you may only access Menconnect if you agree to our privacy policy. " +
+                    "Would you like to change your mind and accept?"),
+        error: get_content("state_generic_error").context(),
+        choices: [
+          new Choice("state_trigger_rapidpro_popi_flow", $("Yes")),
+          new Choice("state_trigger_popi_optout_flow", $("No"))
+        ]
+      });
+    });
+
+    self.add("state_trigger_popi_optout_flow", function (name, opts) {
+      var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
+      var popi_consent = _.toUpper(self.im.user.get_answer("state_menconnect_popi_no_consent_confirm"));
+      var data = {
+          popi_consent: popi_consent,
+      };
+      return self.rapidpro
+        .start_flow(
+          self.im.config.optout_flow_id, null, "whatsapp:" + _.trim(msisdn, "+"), data)
+          .then(function () {
+          return self.states.create("state_menconnect_popi_consent_reject");
+        }).catch(function (e) {
+          // Go to error state after 3 failed HTTP request
+          opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+          if (opts.http_error_count === 3) {
+            self.im.log.error(e.message);
+            return self.states.create("__error__", { 
+              return_state: "state_trigger_popi_optout_flow" 
+            });
+          }
+          return self.states.create("state_trigger_popi_optout_flow", opts);
+        });
+    });
+
+    self.add('state_menconnect_popi_consent_reject', function (name) {
+      return new MenuState(name, {
+        next: "state_trigger_rapidpro_optout_flow",
+        text: $("I'm sorry to see you go! You can dial *134*406# to rejoin. " +
+                    "\n\nFor any medical concerns please visit the clinic." + 
+                    "\n\nStay healthy!" +
+                    "\nMo")
+      });
+    });
+
+    self.add("state_trigger_rapidpro_popi_flow", function(name, opts) {
+      var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
+      var popi_consent = _.toUpper(self.im.user.get_answer("state_menconnect_popi_consent"));
+      var popi_consent_confirm = _.toUpper(self.im.user.get_answer("state_menconnect_popi_no_consent_confirm"));
+      
+      if (typeof self.im.user.get_answer("state_menconnect_popi_no_consent_confirm") === "undefined") {
+          popi_consent = (popi_consent === "YES" || popi_consent === "1") ? self.im.config.popi_consent : "false";
+      } else {
+          popi_consent = (popi_consent_confirm === "YES" || popi_consent_confirm === "1") ? self.im.config.popi_consent : "false";
+      }
+
+      var data = {
+          popi_consent: popi_consent,
+      };
+      return self.rapidpro
+          .start_flow(
+              self.im.config.popi_flow_uuid,
+              null,
+              "whatsapp:" + _.trim(msisdn, "+"), data)
+          .then(function() {
+              return self.states.create("state_menconnect_popi_consent_accept");
+          })
+          .catch(function(e) {
+              // Go to error state after 3 failed HTTP requests
+              opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+              if (opts.http_error_count === 3) {
+                  self.im.log.error(e.message);
+                  return self.states.create("__error__", {
+                      return_state: "state_trigger_rapidpro_popi_flow"
+                  });
+              }
+              return self.states.create("state_trigger_rapidpro_popi_flow", opts);
+          });
+    });
+
+    self.add('state_menconnect_popi_consent_accept', function (name) {
+      return new MenuState(name, {
+        next: "state_start",
+        text: $(
+          "Thank you for accepting the policy."
+        )
       });
     });
 
@@ -1825,7 +1985,7 @@ go.app = (function () {
         "fields.messaging_consent"
       );
       if (consent === "TRUE") {
-        return self.states.create("state_age_group");
+        return self.states.create("state_whatsapp_contact_check");
       }
       return new MenuState(name, {
         question: $(
@@ -1860,8 +2020,29 @@ go.app = (function () {
           new Choice("zul_ZA", $("Zulu")),
           new Choice("sot_ZA", $("Sesotho"))
         ],
-        next: 'state_age_group'
+        next: 'state_whatsapp_contact_check'
       });
+    });
+
+    self.add("state_whatsapp_contact_check", function (name, opts) {
+      var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
+      return self.whatsapp
+        .contact_check(msisdn, true)
+        .then(function (result) {
+          self.im.user.set_answer("on_whatsapp", result);
+          return self.states.create("state_menconnect_popi_new_registration");
+        })
+        .catch(function (e) {
+          // Go to error state after 3 failed HTTP requests
+          opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+          if (opts.http_error_count === 3) {
+            self.im.log.error(e.message);
+            return self.states.create("__error__", {
+              return_state: "state_whatsapp_contact_check"
+            });
+          }
+          return self.states.create("state_whatsapp_contact_check", opts);
+        });
     });
 
     self.add("state_message_consent_denied", function (name) {
@@ -1871,6 +2052,86 @@ go.app = (function () {
           "If you change your mind and want to receive supportive messages in the future," +
           " dial *134*406# and I'll sign you up."
         ),
+      });
+    });
+
+    self.add('state_menconnect_popi_new_registration', function (name) {
+      return new MenuState(name, {
+        question: $(
+          "MenConnect Keeps your personal info private & confidential. It's used with " +
+          "your consent to send you health messages. You can opt out at any time"),
+        error: get_content("state_generic_error").context(),
+        choices: [
+          new Choice("state_menconnect_start_popi_flow_new_registration", $("Next"))
+        ]
+      });
+    });
+
+    self.add('state_menconnect_start_popi_flow_new_registration', function (name, opts) {
+      var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
+      var data = {
+        on_whatsapp: self.im.user.get_answer("on_whatsapp") ? "true" : "false"
+      };
+      return self.rapidpro
+        .start_flow(
+          self.im.config.popi_flow_uuid,
+          null,
+          "whatsapp:" + _.trim(msisdn, "+"), data)
+        .then(function() {
+          return self.states.create("state_menconnect_popi_consent_new_registration");
+        }).catch(function(e) {
+          // Go to error state after 3 failed HTTP requests
+          opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+          if(opts.http_error_count === 3) {
+            self.im.log.error(e.message);
+            return self.states.create("__error__");
+          }
+          return self.states.create("state_start", opts);
+        });
+    });
+
+    self.add('state_menconnect_popi_consent_new_registration', function (name) {
+      var channel = self.im.user.get_answer("on_whatsapp") ? "true" : "false";
+      var message_channel;
+      if(channel){
+        message_channel = "Whatsapp";
+      }
+      else{
+        message_channel = "SMS";
+      }
+      return new MenuState(name, {
+        question: $(
+          "Do you agree to the MenConnect privacy policy that was just sent to you on {{message_channel}}").context({
+            message_channel: message_channel
+      }),
+        error: get_content("state_generic_error").context(),
+        accept_labels: true,
+        choices: [
+          new Choice("state_menconnect_popi_consent_accept_new_registration", $("Yes")),
+          new Choice("state_menconnect_popi_consent_reject_new_registration", $("No"))
+        ]
+      });
+    });
+
+    self.add('state_menconnect_popi_consent_reject_new_registration', function (name) {
+      return new MenuState(name, {
+        next: "state_start",
+        text: $("I'm sorry to see you go! You can dial *134*406# to rejoin. " +
+                    "\n\nFor any medical concerns please visit the clinic." + 
+                    "\n\nStay healthy!" +
+                    "\nMo")
+      });
+    });
+
+    self.add('state_menconnect_popi_consent_accept_new_registration', function (name) {
+      return new MenuState(name, {
+        question: $(
+          "Thank you for accepting the policy."
+        ),
+        error: get_content("state_generic_error").context(),
+        choices: [
+          new Choice("state_age_group", $("Next"))
+        ]
       });
     });
 
@@ -2046,49 +2307,76 @@ go.app = (function () {
     self.add('state_name_mo', function (name) {
       return new FreeText(name, {
         question: get_content(name).context(),
-        next: 'state_whatsapp_contact_check'
+        next: 'state_research_consent_new_registration'
       });
     });
 
-    self.add("state_whatsapp_contact_check", function (name, opts) {
-      var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
-      return self.whatsapp
-        .contact_check(msisdn, true)
-        .then(function (result) {
-          self.im.user.set_answer("on_whatsapp", result);
-          return self.states.create("state_trigger_rapidpro_flow");
-        })
-        .catch(function (e) {
-          // Go to error state after 3 failed HTTP requests
-          opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
-          if (opts.http_error_count === 3) {
-            self.im.log.error(e.message);
-            return self.states.create("__error__", {
-              return_state: "state_whatsapp_contact_check"
-            });
-          }
-          return self.states.create("state_whatsapp_contact_check", opts);
-        });
+    self.add('state_research_consent_new_registration', function (name) {
+      return new MenuState(name, {
+        question: $(
+          "Your feedback can help us make MenConnect better. " +
+          "\n\nWe only contact people who agree." +
+          "\n\nIf you don't want to give feedback, you can still use MenConnect"
+        ),
+        error: get_content("state_generic_error").context(),
+        choices: [
+          new Choice("state_research_consent_new_registration_choice", $("Next"))
+        ]
+      });
+    });
+
+    self.add('state_research_consent_new_registration_choice', function (name) {
+      return new MenuState(name, {
+        question: $(
+          "May we message you to get your feedback on Menconnect?"
+        ),
+        error: get_content("state_generic_error").context(),
+        accept_labels: true,
+        choices: [
+          new Choice("state_research_consent_accept", $("Yes")),
+          new Choice("state_research_consent_reject", $("No"))
+        ]
+      });
+    });
+
+    self.add('state_research_consent_accept', function (name) {
+      return new MenuState(name, {
+        next: "state_trigger_rapidpro_flow",
+        text: $("Thank you for your consent. Your feedback . " +
+                    "will help make MenConnect even better")
+      });
+    });
+
+    self.add('state_research_consent_reject', function (name) {
+      return new MenuState(name, {
+        next: "state_trigger_rapidpro_flow",
+        text: $("No problem, We will NOT contact you for your feedback. " +
+                    "\n\nRemember, you can keep on using MenConnect")
+      });
     });
 
     self.add("state_trigger_rapidpro_flow", function (name, opts) {
       var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
+      var popi_consent = _.toUpper(self.im.user.get_answer("state_menconnect_popi_consent_new_registration")) === "YES" ? self.im.config.popi_consent : "false";
+  
       var data = {
         on_whatsapp: self.im.user.get_answer("on_whatsapp") ? "true" : "false",
-        consent: self.im.user.get_answer("state_message_consent") === "yes" ? "true" : "false",
+        consent: _.toUpper(self.im.user.get_answer("state_message_consent")) === "YES" ? "true" : "false",
         language: self.im.user.get_answer("state_language"),
         source: "USSD registration",
         timestamp: new moment.utc(self.im.config.testing_today).format(),
         registered_by: utils.normalize_msisdn(self.im.user.addr, "ZA"),
         mha: 6,
         swt: self.im.user.get_answer("on_whatsapp") ? 7 : 1,
+        popi_consent: popi_consent,
         age_group: self.im.user.get_answer("state_age_group"),
         status_known_period: self.im.user.get_answer("state_status_known"),
         treatment_adherent: self.im.user.get_answer("state_still_on_treatment") || "No",
         treatment_initiated: self.im.user.get_answer("state_treatment_started"),
         treatment_start_period: self.im.user.get_answer("state_treatment_start_date"),
         viral_load_undetectable: self.im.user.get_answer("state_viral_detect"),
-        name: self.im.user.get_answer("state_name_mo")
+        name: self.im.user.get_answer("state_name_mo"),
+        research_consent: self.im.user.get_answer("state_research_consent_new_registration_choice")
       };
       return self.rapidpro
         .start_flow(

--- a/src/ussd_registration.js
+++ b/src/ussd_registration.js
@@ -1645,7 +1645,7 @@ go.app = (function () {
     });
 
     self.add('state_menconnect_popi_consent_accept', function (name) {
-      return new MenuState(name, {
+      return new EndState(name, {
         next: "state_start",
         text: $(
           "Thank you for accepting the policy."

--- a/src/ussd_registration.js
+++ b/src/ussd_registration.js
@@ -1445,10 +1445,12 @@ go.app = (function () {
         question: get_content(name).context(),
         accept_labels: true,
         choices: [
-          new Choice("state_menconnect_info", $("What info does MenConnect collect?")),
-          new Choice("state_menconnect_info_need", $("Why does MenConnect need my info?")),
+          new Choice("state_menconnect_info", $("What info is collected?")),
+          new Choice("state_menconnect_info_need", $("Why do you need my info?")),
           new Choice("state_menconnect_info_visibility", $("Who can see my info?")),
-          new Choice("state_menconnect_info_duration", $("How long is my info kept?"))
+          new Choice("state_menconnect_info_duration", $("How long is my info kept?")),
+          new Choice("state_menconnect_popi", $("View Privacy Policy")),
+          new Choice("state_registered", $("Back"))
         ]
       });
     });
@@ -1490,6 +1492,164 @@ go.app = (function () {
         choices: [
           new Choice("state_processing_info_menu", $("Back"))
         ]
+      });
+    });
+
+    self.add('state_menconnect_popi', function (name) {
+      return new MenuState(name, {
+        question: $(
+          "MenConnect Keeps your personal info private & confidential. It's used with " +
+          "your consent to send you health messages. You can opt out at any time"),
+        error: get_content("state_generic_error").context(),
+        choices: [
+          new Choice("state_menconnect_start_popi_flow", $("Next"))
+        ]
+      });
+    });
+
+    self.add('state_menconnect_start_popi_flow', function (name, opts) {
+      var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
+      
+      return self.rapidpro
+        .start_flow(
+          self.im.config.popi_flow_uuid,
+          null,
+          "whatsapp:" + _.trim(msisdn, "+"))
+        .then(function() {
+          return self.states.create("state_menconnect_popi_consent");
+        }).catch(function(e) {
+          // Go to error state after 3 failed HTTP requests
+          opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+          if(opts.http_error_count === 3) {
+            self.im.log.error(e.message);
+            return self.states.create("__error__");
+          }
+          return self.states.create("state_start", opts);
+        });
+    });
+
+    self.add('state_menconnect_popi_consent', function (name) {
+      var contact = self.im.user.get_answer("contact");
+      var popi_consent = (_.toUpper(_.get(contact, "fields.popi_consent")));
+      if (popi_consent === self.im.config.popi_consent) {
+        return self.states.create("state_menconnect_popi_consent_view");
+      }
+      return new MenuState(name, {
+        question: $(
+          "Do you agree to the MenConnect privacy policy that was just sent to you on {{current_channel}}").context({
+          current_channel: self.contact_current_channel(contact)
+      }),
+        error: get_content("state_generic_error").context(),
+        accept_labels: true,
+        choices: [
+          new Choice("state_trigger_rapidpro_popi_flow", $("Yes")),
+          new Choice("state_menconnect_popi_no_consent_confirm", $("No"))
+        ]
+      });
+    });
+
+    self.add('state_menconnect_popi_consent_view', function (name) {
+      var contact = self.im.user.answers.contact;
+      return new MenuState(name, {
+        question: $(
+          "The MenConnect privacy policy was just sent to you on {{current_channel}}").context({
+          current_channel: self.contact_current_channel(contact)
+      }),
+        error: get_content("state_generic_error").context(),
+        choices: [
+          new Choice("state_start", $("Menu")),
+          new Choice("state_exit", $("Exit"))
+        ]
+      });
+    });
+
+    self.add('state_menconnect_popi_no_consent_confirm', function (name) {
+      return new MenuState(name, {
+        question: $("Unfortunately you may only access Menconnect if you agree to our privacy policy. " +
+                    "Would you like to change your mind and accept?"),
+        error: get_content("state_generic_error").context(),
+        choices: [
+          new Choice("state_trigger_rapidpro_popi_flow", $("Yes")),
+          new Choice("state_trigger_popi_optout_flow", $("No"))
+        ]
+      });
+    });
+
+    self.add("state_trigger_popi_optout_flow", function (name, opts) {
+      var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
+      var popi_consent = _.toUpper(self.im.user.get_answer("state_menconnect_popi_no_consent_confirm"));
+      var data = {
+          popi_consent: popi_consent,
+      };
+      return self.rapidpro
+        .start_flow(
+          self.im.config.optout_flow_id, null, "whatsapp:" + _.trim(msisdn, "+"), data)
+          .then(function () {
+          return self.states.create("state_menconnect_popi_consent_reject");
+        }).catch(function (e) {
+          // Go to error state after 3 failed HTTP request
+          opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+          if (opts.http_error_count === 3) {
+            self.im.log.error(e.message);
+            return self.states.create("__error__", { 
+              return_state: "state_trigger_popi_optout_flow" 
+            });
+          }
+          return self.states.create("state_trigger_popi_optout_flow", opts);
+        });
+    });
+
+    self.add('state_menconnect_popi_consent_reject', function (name) {
+      return new MenuState(name, {
+        next: "state_trigger_rapidpro_optout_flow",
+        text: $("I'm sorry to see you go! You can dial *134*406# to rejoin. " +
+                    "\n\nFor any medical concerns please visit the clinic." + 
+                    "\n\nStay healthy!" +
+                    "\nMo")
+      });
+    });
+
+    self.add("state_trigger_rapidpro_popi_flow", function(name, opts) {
+      var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
+      var popi_consent = _.toUpper(self.im.user.get_answer("state_menconnect_popi_consent"));
+      var popi_consent_confirm = _.toUpper(self.im.user.get_answer("state_menconnect_popi_no_consent_confirm"));
+      
+      if (typeof self.im.user.get_answer("state_menconnect_popi_no_consent_confirm") === "undefined") {
+          popi_consent = (popi_consent === "YES" || popi_consent === "1") ? self.im.config.popi_consent : "false";
+      } else {
+          popi_consent = (popi_consent_confirm === "YES" || popi_consent_confirm === "1") ? self.im.config.popi_consent : "false";
+      }
+
+      var data = {
+          popi_consent: popi_consent,
+      };
+      return self.rapidpro
+          .start_flow(
+              self.im.config.popi_flow_uuid,
+              null,
+              "whatsapp:" + _.trim(msisdn, "+"), data)
+          .then(function() {
+              return self.states.create("state_menconnect_popi_consent_accept");
+          })
+          .catch(function(e) {
+              // Go to error state after 3 failed HTTP requests
+              opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+              if (opts.http_error_count === 3) {
+                  self.im.log.error(e.message);
+                  return self.states.create("__error__", {
+                      return_state: "state_trigger_rapidpro_popi_flow"
+                  });
+              }
+              return self.states.create("state_trigger_rapidpro_popi_flow", opts);
+          });
+    });
+
+    self.add('state_menconnect_popi_consent_accept', function (name) {
+      return new MenuState(name, {
+        next: "state_start",
+        text: $(
+          "Thank you for accepting the policy."
+        )
       });
     });
 
@@ -1676,7 +1836,7 @@ go.app = (function () {
         "fields.messaging_consent"
       );
       if (consent === "TRUE") {
-        return self.states.create("state_age_group");
+        return self.states.create("state_whatsapp_contact_check");
       }
       return new MenuState(name, {
         question: $(
@@ -1711,8 +1871,29 @@ go.app = (function () {
           new Choice("zul_ZA", $("Zulu")),
           new Choice("sot_ZA", $("Sesotho"))
         ],
-        next: 'state_age_group'
+        next: 'state_whatsapp_contact_check'
       });
+    });
+
+    self.add("state_whatsapp_contact_check", function (name, opts) {
+      var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
+      return self.whatsapp
+        .contact_check(msisdn, true)
+        .then(function (result) {
+          self.im.user.set_answer("on_whatsapp", result);
+          return self.states.create("state_menconnect_popi_new_registration");
+        })
+        .catch(function (e) {
+          // Go to error state after 3 failed HTTP requests
+          opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+          if (opts.http_error_count === 3) {
+            self.im.log.error(e.message);
+            return self.states.create("__error__", {
+              return_state: "state_whatsapp_contact_check"
+            });
+          }
+          return self.states.create("state_whatsapp_contact_check", opts);
+        });
     });
 
     self.add("state_message_consent_denied", function (name) {
@@ -1722,6 +1903,86 @@ go.app = (function () {
           "If you change your mind and want to receive supportive messages in the future," +
           " dial *134*406# and I'll sign you up."
         ),
+      });
+    });
+
+    self.add('state_menconnect_popi_new_registration', function (name) {
+      return new MenuState(name, {
+        question: $(
+          "MenConnect Keeps your personal info private & confidential. It's used with " +
+          "your consent to send you health messages. You can opt out at any time"),
+        error: get_content("state_generic_error").context(),
+        choices: [
+          new Choice("state_menconnect_start_popi_flow_new_registration", $("Next"))
+        ]
+      });
+    });
+
+    self.add('state_menconnect_start_popi_flow_new_registration', function (name, opts) {
+      var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
+      var data = {
+        on_whatsapp: self.im.user.get_answer("on_whatsapp") ? "true" : "false"
+      };
+      return self.rapidpro
+        .start_flow(
+          self.im.config.popi_flow_uuid,
+          null,
+          "whatsapp:" + _.trim(msisdn, "+"), data)
+        .then(function() {
+          return self.states.create("state_menconnect_popi_consent_new_registration");
+        }).catch(function(e) {
+          // Go to error state after 3 failed HTTP requests
+          opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
+          if(opts.http_error_count === 3) {
+            self.im.log.error(e.message);
+            return self.states.create("__error__");
+          }
+          return self.states.create("state_start", opts);
+        });
+    });
+
+    self.add('state_menconnect_popi_consent_new_registration', function (name) {
+      var channel = self.im.user.get_answer("on_whatsapp") ? "true" : "false";
+      var message_channel;
+      if(channel){
+        message_channel = "Whatsapp";
+      }
+      else{
+        message_channel = "SMS";
+      }
+      return new MenuState(name, {
+        question: $(
+          "Do you agree to the MenConnect privacy policy that was just sent to you on {{message_channel}}").context({
+            message_channel: message_channel
+      }),
+        error: get_content("state_generic_error").context(),
+        accept_labels: true,
+        choices: [
+          new Choice("state_menconnect_popi_consent_accept_new_registration", $("Yes")),
+          new Choice("state_menconnect_popi_consent_reject_new_registration", $("No"))
+        ]
+      });
+    });
+
+    self.add('state_menconnect_popi_consent_reject_new_registration', function (name) {
+      return new MenuState(name, {
+        next: "state_start",
+        text: $("I'm sorry to see you go! You can dial *134*406# to rejoin. " +
+                    "\n\nFor any medical concerns please visit the clinic." + 
+                    "\n\nStay healthy!" +
+                    "\nMo")
+      });
+    });
+
+    self.add('state_menconnect_popi_consent_accept_new_registration', function (name) {
+      return new MenuState(name, {
+        question: $(
+          "Thank you for accepting the policy."
+        ),
+        error: get_content("state_generic_error").context(),
+        choices: [
+          new Choice("state_age_group", $("Next"))
+        ]
       });
     });
 
@@ -1897,49 +2158,76 @@ go.app = (function () {
     self.add('state_name_mo', function (name) {
       return new FreeText(name, {
         question: get_content(name).context(),
-        next: 'state_whatsapp_contact_check'
+        next: 'state_research_consent_new_registration'
       });
     });
 
-    self.add("state_whatsapp_contact_check", function (name, opts) {
-      var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
-      return self.whatsapp
-        .contact_check(msisdn, true)
-        .then(function (result) {
-          self.im.user.set_answer("on_whatsapp", result);
-          return self.states.create("state_trigger_rapidpro_flow");
-        })
-        .catch(function (e) {
-          // Go to error state after 3 failed HTTP requests
-          opts.http_error_count = _.get(opts, "http_error_count", 0) + 1;
-          if (opts.http_error_count === 3) {
-            self.im.log.error(e.message);
-            return self.states.create("__error__", {
-              return_state: "state_whatsapp_contact_check"
-            });
-          }
-          return self.states.create("state_whatsapp_contact_check", opts);
-        });
+    self.add('state_research_consent_new_registration', function (name) {
+      return new MenuState(name, {
+        question: $(
+          "Your feedback can help us make MenConnect better. " +
+          "\n\nWe only contact people who agree." +
+          "\n\nIf you don't want to give feedback, you can still use MenConnect"
+        ),
+        error: get_content("state_generic_error").context(),
+        choices: [
+          new Choice("state_research_consent_new_registration_choice", $("Next"))
+        ]
+      });
+    });
+
+    self.add('state_research_consent_new_registration_choice', function (name) {
+      return new MenuState(name, {
+        question: $(
+          "May we message you to get your feedback on Menconnect?"
+        ),
+        error: get_content("state_generic_error").context(),
+        accept_labels: true,
+        choices: [
+          new Choice("state_research_consent_accept", $("Yes")),
+          new Choice("state_research_consent_reject", $("No"))
+        ]
+      });
+    });
+
+    self.add('state_research_consent_accept', function (name) {
+      return new MenuState(name, {
+        next: "state_trigger_rapidpro_flow",
+        text: $("Thank you for your consent. Your feedback . " +
+                    "will help make MenConnect even better")
+      });
+    });
+
+    self.add('state_research_consent_reject', function (name) {
+      return new MenuState(name, {
+        next: "state_trigger_rapidpro_flow",
+        text: $("No problem, We will NOT contact you for your feedback. " +
+                    "\n\nRemember, you can keep on using MenConnect")
+      });
     });
 
     self.add("state_trigger_rapidpro_flow", function (name, opts) {
       var msisdn = utils.normalize_msisdn(self.im.user.addr, "ZA");
+      var popi_consent = _.toUpper(self.im.user.get_answer("state_menconnect_popi_consent_new_registration")) === "YES" ? self.im.config.popi_consent : "false";
+  
       var data = {
         on_whatsapp: self.im.user.get_answer("on_whatsapp") ? "true" : "false",
-        consent: self.im.user.get_answer("state_message_consent") === "yes" ? "true" : "false",
+        consent: _.toUpper(self.im.user.get_answer("state_message_consent")) === "YES" ? "true" : "false",
         language: self.im.user.get_answer("state_language"),
         source: "USSD registration",
         timestamp: new moment.utc(self.im.config.testing_today).format(),
         registered_by: utils.normalize_msisdn(self.im.user.addr, "ZA"),
         mha: 6,
         swt: self.im.user.get_answer("on_whatsapp") ? 7 : 1,
+        popi_consent: popi_consent,
         age_group: self.im.user.get_answer("state_age_group"),
         status_known_period: self.im.user.get_answer("state_status_known"),
         treatment_adherent: self.im.user.get_answer("state_still_on_treatment") || "No",
         treatment_initiated: self.im.user.get_answer("state_treatment_started"),
         treatment_start_period: self.im.user.get_answer("state_treatment_start_date"),
         viral_load_undetectable: self.im.user.get_answer("state_viral_detect"),
-        name: self.im.user.get_answer("state_name_mo")
+        name: self.im.user.get_answer("state_name_mo"),
+        research_consent: self.im.user.get_answer("state_research_consent_new_registration_choice")
       };
       return self.rapidpro
         .start_flow(

--- a/test/ussd_registration.test.js
+++ b/test/ussd_registration.test.js
@@ -783,7 +783,7 @@ describe("state_submit_opt_out", function() {
       .setup(function(api) {
         api.http.fixtures.add(
           fixtures_rapidpro.start_flow(
-            "optout-flow-id", 
+            "optout-flow-id",
             null,
             "whatsapp:27123456789",
             {
@@ -823,7 +823,7 @@ describe("state_submit_opt_out", function() {
       .setup(function(api) {
         api.http.fixtures.add(
           fixtures_rapidpro.start_flow(
-            "optout-flow-id", 
+            "optout-flow-id",
             null,
             "whatsapp:27123456789",
             {
@@ -863,7 +863,7 @@ describe("state_submit_opt_out", function() {
       .setup(function(api) {
         api.http.fixtures.add(
           fixtures_rapidpro.start_flow(
-            "optout-flow-id", 
+            "optout-flow-id",
             null,
             "whatsapp:27123456789",
             {
@@ -1369,17 +1369,13 @@ describe("POPI update for existing users", function() {
       .run();
   });
 
-  /********************************************************/
-  /********Failing test so commenting out for now********/
-  /********************************************************/
-
-  /*it("should submit the popi consent", function() {
+  it("should submit the popi consent", function() {
     return tester
         .setup.user.state("state_trigger_rapidpro_popi_flow")
         .setup.user.answers({
-            state_trigger_rapidpro_popi_flow: "Yes",
+            state_menconnect_popi_consent: "Yes",
             fields:{
-              popi_consent: "10-2021"
+              popi_consent: "yes"
             }
         })
         .setup(function(api) {
@@ -1394,7 +1390,7 @@ describe("POPI update for existing users", function() {
         .check.interaction({
             state: "state_menconnect_popi_consent_accept",
             reply: [
-                "You will receive messages in eng_ZA from now on."
+                "Thank you for accepting the policy."
             ].join("\n")
         })
         .check(function(api) {
@@ -1404,7 +1400,7 @@ describe("POPI update for existing users", function() {
             );
         })
         .run();
-  });*/
+  });
 });
 describe("state_share", function() {
   it("should show the share menu", function() {

--- a/test/ussd_registration.test.js
+++ b/test/ussd_registration.test.js
@@ -36,7 +36,9 @@ describe("ussd_registration app", function() {
       whatsapp_switch_flow_id: "whatsapp-switch-flow-id",
       change_next_clinic_visit_flow_id: "change-next-clinic-visit-flow-id",
       send_sms_flow_id: "send-sms-flow-id",
-      optout_flow_id: "optout-flow-id"
+      optout_flow_id: "optout-flow-id",
+      popi_consent: "12-2021",
+      popi_flow_uuid: "popi-flow-uuid"
     })
     .setup(function(api) {
       api.metrics.stores = {'test_metric_store': {}};
@@ -554,7 +556,7 @@ describe("state_reminders", function() {
   it("should show the clinic confirm screen on valid input", function() {
     return tester
       .setup.user.state("state_new_clinic_date")
-      .input("2021-02-24")
+      .input("2022-02-24")
       .check.user.state("state_clinic_date_display")
       .check(function(api){
         var metrics = api.metrics.stores.test_metric_store;
@@ -568,11 +570,7 @@ describe("state_reminders", function() {
       .input("2021-02-24")
       .check.interaction({
         reply:[
-          "You entered 2021-02-24. " +
-          "I'll send you reminders of your upcoming clinic visits " +
-          "so that you don't forget.",
-          "1. Confirm",
-          "2. Back"
+          "Oops, that day has already passed. Please try again."
         ].join("\n")
       })
       .run();
@@ -717,7 +715,7 @@ describe("state_profile", function() {
   it("should show the reminder confirm screen on valid input", function() {
     return tester
       .setup.user.state("state_new_clinic_date_opt_out")
-      .input("2021-02-24")
+      .input("2022-02-24")
       .check.user.state("state_clinic_reminder_confirm")
       .check(function(api){
         var metrics = api.metrics.stores.test_metric_store;
@@ -728,7 +726,7 @@ describe("state_profile", function() {
   it("should return errors for invalid input", function() {
     return tester
       .setup.user.state("state_new_clinic_date_opt_out")
-      .input("2022-06-24")
+      .input("2023-06-24")
       .check.interaction({
         reply:[
           "Hmm, that seems a bit far away. " +
@@ -1328,10 +1326,12 @@ describe("state_processing_info_menu", function() {
       .check.interaction({
         reply: [
           "Choose a question:",
-          "1. What info does MenConnect collect?",
-          "2. Why does MenConnect need my info?",
+          "1. What info is collected?",
+          "2. Why do you need my info?",
           "3. Who can see my info?",
-          "4. How long is my info kept?"
+          "4. How long is my info kept?",
+          "5. View Privacy Policy",
+          "6. Back"
         ].join("\n")
       })
       .run();
@@ -1353,6 +1353,59 @@ describe("state_processing_info_menu", function() {
   });
 });
 
+describe("POPI update for existing users", function() {
+  it("should show the popi screen", function() {
+    return tester.setup.user
+      .state("state_processing_info_menu")
+      .inputs("5")
+      .check.interaction({
+        state:"state_menconnect_popi",
+        reply: [
+          "MenConnect Keeps your personal info private & confidential. It's used with " +
+          "your consent to send you health messages. You can opt out at any time",
+          "1. Next"
+        ].join("\n")
+      })
+      .run();
+  });
+
+  /********************************************************/
+  /********Failing test so commenting out for now********/
+  /********************************************************/
+
+  /*it("should submit the popi consent", function() {
+    return tester
+        .setup.user.state("state_trigger_rapidpro_popi_flow")
+        .setup.user.answers({
+            state_trigger_rapidpro_popi_flow: "Yes",
+            fields:{
+              popi_consent: "10-2021"
+            }
+        })
+        .setup(function(api) {
+            api.http.fixtures.add(
+                fixtures_rapidpro.start_flow(
+                  "popi-flow-uuid", null, "whatsapp:27123456789", {
+                    "popi_consent": "12-2021"
+                })
+            );
+        })
+        .input("1")
+        .check.interaction({
+            state: "state_menconnect_popi_consent_accept",
+            reply: [
+                "You will receive messages in eng_ZA from now on."
+            ].join("\n")
+        })
+        .check(function(api) {
+            assert.equal(api.http.requests.length, 1);
+            assert.equal(
+                api.http.requests[0].url, "https://rapidpro/api/v2/flow_starts.json"
+            );
+        })
+        .run();
+  });*/
+});
 describe("state_share", function() {
   it("should show the share menu", function() {
     return tester.setup.user
@@ -2000,13 +2053,15 @@ describe("state_share", function() {
         .setup.user.answers({
           state_message_consent: "yes",
           state_language: "eng",
+          state_menconnect_popi_consent_new_registration: "yes",
           state_age_group: "<15",
           state_status_known: "<3 months",
           state_still_on_treatment: "yes",
           state_treatment_started: "yes",
           state_treatment_start_date: "<1 month",
           state_viral_detect: "yes",
-          state_name_mo: "Jerry"
+          state_name_mo: "Jerry",
+          state_research_consent_new_registration_choice: "Yes"
         })
         .setup(function(api) {
           api.http.fixtures.add(
@@ -2023,13 +2078,15 @@ describe("state_share", function() {
                 "registered_by":"+27123456789",
                 "mha":6,
                 "swt":7,
+                "popi_consent": "12-2021",
                 "age_group":"<15",
                 "status_known_period":"<3 months",
                 "treatment_adherent": "yes",
                 "treatment_initiated":"yes",
                 "treatment_start_period":"<1 month",
                 "viral_load_undetectable":"yes",
-                "name":"Jerry"
+                "name":"Jerry",
+                "research_consent": "Yes"
               }
             )
           );
@@ -2045,12 +2102,14 @@ describe("state_share", function() {
         .setup.user.answers({
           state_message_consent: "yes",
           state_language: "eng",
+          state_menconnect_popi_consent_new_registration: "yes",
           state_age_group: "<15",
           state_status_known: "<3 months",
           state_treatment_started: "yes",
           state_treatment_start_date: "<1 month",
           state_viral_detect: "yes",
-          state_name_mo: "Jerry"
+          state_name_mo: "Jerry",
+          state_research_consent_new_registration_choice: "Yes"
         })
         .setup(function(api) {
           api.http.fixtures.add(
@@ -2067,13 +2126,15 @@ describe("state_share", function() {
                 "registered_by":"+27123456789",
                 "mha":6,
                 "swt":7,
+                "popi_consent": "12-2021",
                 "age_group":"<15",
                 "status_known_period":"<3 months",
                 "treatment_adherent": "No",
                 "treatment_initiated":"yes",
                 "treatment_start_period":"<1 month",
                 "viral_load_undetectable":"yes",
-                "name":"Jerry"
+                "name":"Jerry",
+                "research_consent": "Yes"
               }
             )
           );
@@ -2090,13 +2151,15 @@ describe("state_share", function() {
         .setup.user.answers({
           state_message_consent: "yes",
           state_language: "eng",
+          state_menconnect_popi_consent_new_registration: "yes",
           state_age_group: "<15",
           state_status_known: "<3 months",
           state_still_on_treatment: "yes",
           state_treatment_started: "yes",
           state_treatment_start_date: "<1 month",
           state_viral_detect: "yes",
-          state_name_mo: "Jerry"
+          state_name_mo: "Jerry",
+          state_research_consent_new_registration_choice: "Yes"
         })
         .setup(function(api) {
           api.http.fixtures.add(
@@ -2113,13 +2176,15 @@ describe("state_share", function() {
                 "registered_by":"+27123456789",
                 "mha":6,
                 "swt":1,
+                "popi_consent": "12-2021",
                 "age_group":"<15",
                 "status_known_period":"<3 months",
                 "treatment_adherent":"yes",
                 "treatment_initiated":"yes",
                 "treatment_start_period":"<1 month",
                 "viral_load_undetectable":"yes",
-                "name":"Jerry"
+                "name":"Jerry",
+                "research_consent": "Yes"
               },
               true
             )
@@ -2150,13 +2215,15 @@ describe("state_share", function() {
         .setup.user.answers({
           state_message_consent: "yes",
           state_language: "eng",
+          state_menconnect_popi_consent_new_registration: "yes",
           state_age_group: "<15",
           state_status_known: "<3 months",
           state_still_on_treatment: "yes",
           state_treatment_started: "yes",
           state_treatment_start_date: "<1 month",
           state_viral_detect: "yes",
-          state_name_mo: "Jerry"
+          state_name_mo: "Jerry",
+          state_research_consent_new_registration_choice: "Yes"
         })
           .setup(function(api) {
             api.http.fixtures.add(
@@ -2179,21 +2246,23 @@ describe("state_share", function() {
                   "registered_by":"+27123456789",
                   "mha":6,
                   "swt":7,
+                  "popi_consent": "12-2021",
                   "age_group":"<15",
                   "status_known_period":"<3 months",
                   "treatment_adherent":"yes",
                   "treatment_initiated":"yes",
                   "treatment_start_period":"<1 month",
                   "viral_load_undetectable":"yes",
-                  "name":"Jerry"
+                  "name":"Jerry",
+                  "research_consent": "Yes"
                 }
               )
             );
           })
           // For some reason, if we start the test on state_registration_complete, it skips to state_start,
           // so we need to start it before
-          .setup.user.state("state_whatsapp_contact_check")
-          .setup.user.answer("on_whatsapp", false)
+          //.setup.user.state("state_whatsapp_contact_check")
+          .setup.user.answer("on_whatsapp", true)
           .input({ session_event: "continue" })
           .check.interaction({
             state: "state_registration_complete",
@@ -2216,6 +2285,7 @@ describe("state_share", function() {
         .setup.user.answers({
           state_message_consent: "yes",
           state_language: "eng",
+          state_menconnect_popi_consent_new_registration: "yes",
           state_age_group: "<15",
           state_status_known: "<3 months",
           state_still_on_treatment: "yes",
@@ -2223,6 +2293,7 @@ describe("state_share", function() {
           state_treatment_start_date: "<1 month",
           state_viral_detect: "yes",
           state_name_mo: "Jerry",
+          state_research_consent_new_registration_choice: "Yes",
           on_whatsapp: false
         })
           .setup(function(api) {
@@ -2246,20 +2317,21 @@ describe("state_share", function() {
                   "registered_by":"+27123456789",
                   "mha":6,
                   "swt":1,
+                  "popi_consent": "12-2021",
                   "age_group":"<15",
                   "status_known_period":"<3 months",
                   "treatment_adherent":"yes",
                   "treatment_initiated":"yes",
                   "treatment_start_period":"<1 month",
                   "viral_load_undetectable":"yes",
-                  "name":"Jerry"
+                  "name":"Jerry",
+                  "research_consent": "Yes"
                 }
               )
             );
           })
           // For some reason, if we start the test on state_registration_complete, it skips to state_start,
           // so we need to start it before
-          .setup.user.state("state_whatsapp_contact_check")
           .input({ session_event: "continue" })
           .check.interaction({
             state: "state_registration_complete",


### PR DESCRIPTION
This PR is incomplete. 

What's left: 
Fix commented out test (on line 1372)
Test the optout flow for POPI no consent

In Menconnect Docker:
Add popi_flow_uuid (and create in Rapidpro)
Add popi_consent value (This is the POPI version in rapidpro) - If there's a way to directly fetch rapidpro global variables in the USSD app then we can do that instead.